### PR TITLE
Fixed scaling error in all code files

### DIFF
--- a/JAGS code/3_Combined_M2.R
+++ b/JAGS code/3_Combined_M2.R
@@ -124,7 +124,7 @@ for(j in 1:N_sites){
   for(t in 2:N_years){
     
     Density[j,t] <- (Density[j,t-1] * S[t]) + (Density[j, t-1] * S[t]*R_year[t]/2) ## Process model
-    N_exp[j,t] <- Density[j,t]*L[j,t]*(W*scale1)*2
+    N_exp[j,t] <- Density[j,t]*L[j,t]*(W/scale1)*2
     
     ## Detection model year 2 - T
     N_line_year[j,t] ~ dpois(p[t]*N_exp[j,t]+0.01)

--- a/JAGS code/3_Combined_M3.R
+++ b/JAGS code/3_Combined_M3.R
@@ -125,7 +125,7 @@ for(j in 1:N_sites){
     
     ## Process model
     Density[j,t] <- (Density[j,t-1] * S) + (Density[j, t-1]*S*R_year[t]/2) 
-    N_exp[j,t] <- Density[j,t]*L[j,t]*(W*scale1)*2
+    N_exp[j,t] <- Density[j,t]*L[j,t]*(W/scale1)*2
     
     ## Detection model year 2 - T
     N_line_year[j,t] ~ dpois(p[t]*N_exp[j,t])

--- a/JAGS code/3_Combined_M3b_KnownFate.R
+++ b/JAGS code/3_Combined_M3b_KnownFate.R
@@ -139,7 +139,7 @@ for(j in 1:N_sites){
     
     ## Process model
     Density[j,t] <- (Density[j,t-1] * (S1*S2)) + (Density[j, t-1]*(S1*S2)*R_year[t]/2) 
-    N_exp[j,t] <- Density[j,t]*L[j,t]*(W*scale1)*2
+    N_exp[j,t] <- Density[j,t]*L[j,t]*(W/scale1)*2
     
     ## Detection model year 2 - T
     N_line_year[j,t] ~ dpois(p[t]*N_exp[j,t])

--- a/JAGS code/3_Combined_M4.R
+++ b/JAGS code/3_Combined_M4.R
@@ -127,7 +127,7 @@ for(j in 1:N_sites){
     
     ## Process model
     Density[j,t] <- (Density[j,t-1] * S) + (Density[j, t-1]*S*R_year[t]/2) 
-    N_exp[j,t] <- Density[j,t]*L[j,t]*(W*scale1)*2
+    N_exp[j,t] <- Density[j,t]*L[j,t]*(W/scale1)*2
     
     ## Detection model year 2 - T
     N_line_year[j,t] ~ dpois(p[t]*N_exp[j,t])

--- a/JAGS code/3_Combined_M5.R
+++ b/JAGS code/3_Combined_M5.R
@@ -150,7 +150,7 @@ for(j in 1:N_sites){
     
     ## Process model
     Density[j,t] <- (Density[j,t-1] * S) + (Density[j, t-1]*S*R_year[t]/2) 
-    N_exp[j,t] <- Density[j,t]*L[j,t]*(W*scale1)*2
+    N_exp[j,t] <- Density[j,t]*L[j,t]*(W/scale1)*2
     
     ## Detection model year 2 - T
     N_line_year[j,t] ~ dpois(p[t]*N_exp[j,t])

--- a/JAGS code/3_Combined_M6.R
+++ b/JAGS code/3_Combined_M6.R
@@ -144,7 +144,7 @@ for(j in 1:N_sites){
     
     ## Process model
     Density[j,t] <- (Density[j,t-1] * S) + (Density[j, t-1]*S*R_year[t]/2) 
-    N_exp[j,t] <- Density[j,t]*L[j,t]*(W*scale1)*2
+    N_exp[j,t] <- Density[j,t]*L[j,t]*(W/scale1)*2
     
     ## Detection model year 2 - T
     N_line_year[j,t] ~ dpois(p[t]*N_exp[j,t])

--- a/JAGS code/3_Combined_M7.R
+++ b/JAGS code/3_Combined_M7.R
@@ -147,7 +147,7 @@ for(j in 1:N_sites){
     
     ## Process model
     Density[j,t] <- (Density[j,t-1] * S) + (Density[j, t-1]*S*R_year[t]/2) 
-    N_exp[j,t] <- Density[j,t]*L[j,t]*(W*scale1)*2
+    N_exp[j,t] <- Density[j,t]*L[j,t]*(W/scale1)*2
     
     ## Detection model year 2 - T
     N_line_year[j,t] ~ dpois(p[t]*N_exp[j,t])

--- a/NIMBLE code/3_Combined_M2_nimble.R
+++ b/NIMBLE code/3_Combined_M2_nimble.R
@@ -123,7 +123,7 @@ modM2.code <- nimbleCode({
     for(t in 2:N_years){
       
       Density[j, t] <- (Density[j, t-1] * S[t]) + (Density[j, t-1] * S[t]*R_year[t]/2) ## Process model
-      N_exp[j, t] <- Density[j, t]*L[j, t]*(W*scale1)*2
+      N_exp[j, t] <- Density[j, t]*L[j, t]*(W/scale1)*2
       
       ## Detection model year 2 - T
       N_line_year[j, t] ~ dpois(p[t]*N_exp[j, t]+0.01)

--- a/NIMBLE code/3_Combined_M3_nimble.R
+++ b/NIMBLE code/3_Combined_M3_nimble.R
@@ -122,7 +122,7 @@ modM3.code <- nimbleCode({
       
       ## Process model
       Density[j, t] <- (Density[j, t-1] * S) + (Density[j, t-1]*S*R_year[t]/2) 
-      N_exp[j, t] <- Density[j, t]*L[j, t]*(W*scale1)*2
+      N_exp[j, t] <- Density[j, t]*L[j, t]*(W/scale1)*2
       
       ## Detection model year 2 - T
       N_line_year[j, t] ~ dpois(p[t]*N_exp[j, t])

--- a/NIMBLE code/3_Combined_M3b_KnownFate_nimble.R
+++ b/NIMBLE code/3_Combined_M3b_KnownFate_nimble.R
@@ -138,7 +138,7 @@ modM3b.code.A <- nimbleCode({
       
       ## Process model
       Density[j, t] <- (Density[j, t-1] * S[t-1]) + (Density[j, t-1]*S[t-1]*R_year[t]/2) 
-      N_exp[j, t] <- Density[j, t]*L[j, t]*(W*scale1)*2
+      N_exp[j, t] <- Density[j, t]*L[j, t]*(W/scale1)*2
       
       ## Detection model year 2 - T
       N_line_year[j, t] ~ dpois(p[t]*N_exp[j, t])

--- a/NIMBLE code/3_Combined_M3b_KnownFate_nimble_Alt.R
+++ b/NIMBLE code/3_Combined_M3b_KnownFate_nimble_Alt.R
@@ -154,7 +154,7 @@ rypeIDSM <- nimbleCode({
       Density[2, j, t] <- sum(Density[1:N_ageC, j, t-1])*S[t-1] # Juveniles
       Density[1, j, t] <- Density[2, j, t]*R_year[t]/2 # Adults
 
-      N_exp[1:N_ageC, j, t] <- Density[1:N_ageC, j, t]*L[j, t]*(W*scale1)*2
+      N_exp[1:N_ageC, j, t] <- Density[1:N_ageC, j, t]*L[j, t]*(W/scale1)*2
       
       ## Detection model year 2 - T
       #for(x in 1:N_ageC){

--- a/NIMBLE code/3_Combined_M4_nimble.R
+++ b/NIMBLE code/3_Combined_M4_nimble.R
@@ -122,7 +122,7 @@ modM4.code <- nimbleCode({
       
       ## Process model
       Density[j, t] <- (Density[j, t-1] * S) + (Density[j, t-1]*S*R_year[t]/2) 
-      N_exp[j, t] <- Density[j, t]*L[j, t]*(W*scale1)*2
+      N_exp[j, t] <- Density[j, t]*L[j, t]*(W/scale1)*2
       
       ## Detection model year 2 - T
       N_line_year[j, t] ~ dpois(p[t]*N_exp[j, t])

--- a/NIMBLE code/rypeIDSM.R
+++ b/NIMBLE code/rypeIDSM.R
@@ -151,7 +151,7 @@ rypeIDSM <- nimbleCode({
       Density[2, j, t] <- sum(Density[1:N_ageC, j, t-1])*S[t-1] # Juveniles
       Density[1, j, t] <- Density[2, j, t]*R_year[t]/2 # Adults
       
-      N_exp[1:N_ageC, j, t] <- Density[1:N_ageC, j, t]*L[j, t]*(W*scale1)*2
+      N_exp[1:N_ageC, j, t] <- Density[1:N_ageC, j, t]*L[j, t]*(W/scale1)*2
       
       ## Detection model year 2 - T
       for(x in 1:N_ageC){


### PR DESCRIPTION
There was a typo in one of the earliest code files where area scaling was W*scale1 instead of W/scale1. This early error propagated into all later code files. 
This pull request fixes that error in all affected files. 