### PR TITLE
Update to use z-standardized rodent covariate

### DIFF
--- a/Analysis_RealData_LierneVest.R
+++ b/Analysis_RealData_LierneVest.R
@@ -103,7 +103,7 @@ d_rodent <- wrangleData_Rodent(duplTransects = duplTransects,
 input_data <- prepareInputData(d_trans = LT_data$d_trans, 
                                d_obs = LT_data$d_obs,
                                d_cmr = d_cmr,
-                               d_rodent = d_rodent,
+                               d_rodent = d_rodent$rodentAvg,
                                localities = localities, 
                                #areas = areas,
                                areaAggregation = areaAggregation,
@@ -153,14 +153,14 @@ IDSM.out <- nimbleMCMC(code = model_setup$modelCode,
                        setSeed = mySeed)
 Sys.time() - t.start
 
-saveRDS(IDSM.out, file = 'rypeIDSM_dHN_multiArea_realData_Lierne.rds')
+saveRDS(IDSM.out, file = 'rypeIDSM_dHN_multiArea_realData_Lierne_rodentEffZ.rds')
 
 
 # TIDY UP POSTERIOR SAMPLES #
 #---------------------------#
 
 IDSM.out.tidy <- tidySamples(IDSM.out = IDSM.out, save = FALSE)
-saveRDS(IDSM.out.tidy, file = 'rypeIDSM_dHN_multiArea_realData_Lierne_tidy.rds')
+saveRDS(IDSM.out.tidy, file = 'rypeIDSM_dHN_multiArea_realData_Lierne_rodentEffZ_tidy.rds')
 
 
 # OPTIONAL: MCMC TRACE PLOTS #
@@ -206,6 +206,8 @@ if(fitRodentCov){
                     covName = "Rodent occupancy",
                     minCov = 0, 
                     maxCov = 1,
+                    meanCov_std = d_rodent$meanCov,
+                    sdCov_std = d_rodent$sdCov,
                     N_areas = input_data$nim.constant$N_areas, 
                     area_names = input_data$nim.constant$area_names,
                     fitRodentCov = fitRodentCov)

--- a/Analysis_RealData_LierneVest.R
+++ b/Analysis_RealData_LierneVest.R
@@ -206,8 +206,8 @@ if(fitRodentCov){
                     covName = "Rodent occupancy",
                     minCov = 0, 
                     maxCov = 1,
-                    meanCov_std = d_rodent$meanCov,
-                    sdCov_std = d_rodent$sdCov,
+                    meanCov = d_rodent$meanCov,
+                    sdCov = d_rodent$sdCov,
                     N_areas = input_data$nim.constant$N_areas, 
                     area_names = input_data$nim.constant$area_names,
                     fitRodentCov = fitRodentCov)

--- a/Analysis_RealData_LierneVest.R
+++ b/Analysis_RealData_LierneVest.R
@@ -43,7 +43,7 @@ shareRE <- TRUE
 survVarT <- FALSE
 
 # Rodent covariate on reproduction
-fitRodentCov <- FALSE
+fitRodentCov <- TRUE
 
 # DOWNLOAD/FETCH DATA #
 #---------------------#

--- a/NIMBLE code/rypeIDSM_multiArea_dHN.R
+++ b/NIMBLE code/rypeIDSM_multiArea_dHN.R
@@ -229,7 +229,7 @@ rypeIDSM <- nimbleCode({
   if(fitRodentCov){
     for(x in 1:N_areas){
       for (t in 1:N_years){
-        RodentOcc[x, t] ~ dunif(0, 1)
+        RodentOcc[x, t] ~ dnorm(0, sd = 1)
       }
     }
   }

--- a/R/plotCovPrediction.R
+++ b/R/plotCovPrediction.R
@@ -33,7 +33,7 @@ plotCovPrediction <- function(mcmc.out,
   if(fitRodentCov){
     ## Make sequence of absolute and z-standardized covariate values to predict for
     cov_abs <- seq(minCov, maxCov, length.out = 100)
-    cov <- (cov_abs - meanCov) / sd_Cov
+    cov <- (cov_abs - meanCov) / sdCov
   
     ## Assemble dataframe for storing posterior summaries of predictions
     cov.pred.data <- data.frame()

--- a/R/plotCovPrediction.R
+++ b/R/plotCovPrediction.R
@@ -9,6 +9,10 @@
 #' @param covName character string that defines the covariate.
 #' @param minCov numeric. Minimum covariate value to predict for.
 #' @param maxCov numeric. Maximum covariate value to predict for.
+#' @param meanCov numeric. Mean value of the original covariate (used for z-
+#' standardization).
+#' @param sdCov numeric. Standard deviation of the original covariate (used for 
+#' z-standardization).
 #' @param N_areas integer. Number of areas included in analyses. 
 #' @param area_names character vector containing area/location names.
 #' @param fitRodentCov logical. If TRUE, plots are made for predictions with 
@@ -22,13 +26,15 @@
 plotCovPrediction <- function(mcmc.out, 
                               effectParam, covName,
                               minCov, maxCov,
+                              meanCov, sdCov,
                               N_areas, area_names,
                               fitRodentCov){
   
   if(fitRodentCov){
-    ## Make sequence of covariate values to predict for
-    cov <- seq(minCov, maxCov, length.out = 100)
-    
+    ## Make sequence of absolute and z-standardized covariate values to predict for
+    cov_abs <- seq(minCov, maxCov, length.out = 100)
+    cov <- (cov_abs - meanCov) / sd_Cov
+  
     ## Assemble dataframe for storing posterior summaries of predictions
     cov.pred.data <- data.frame()
     
@@ -42,7 +48,8 @@ plotCovPrediction <- function(mcmc.out,
       for(x in 1:100){
         R.pred <- exp(log(Mu.R) + beta*cov[x])
         cov.pred.temp <- data.frame(Area = area_names[i], 
-                                    covValue = cov[x], 
+                                    covValue_z = cov[x], 
+                                    covValue = cov_abs[x], 
                                     pred_Median = median(R.pred),
                                     pred_lCI = unname(quantile(R.pred, probs = 0.025)),
                                     pred_uCI = unname(quantile(R.pred, probs = 0.975)))

--- a/R/simulateInits.R
+++ b/R/simulateInits.R
@@ -45,7 +45,7 @@ simulateInits <- function(nim.data, nim.constants, R_perF, shareRE, survVarT, fi
   }
   
   if(NA %in% RodentOcc){
-    RodentOcc[which(is.na(RodentOcc))] <- runif(length(which(is.na(RodentOcc))), 0, 1)
+    RodentOcc[which(is.na(RodentOcc))] <- rnorm(length(which(is.na(RodentOcc))), 0, 1)
   }
   
   Inits_RodentOcc <- RodentOcc

--- a/R/wrangleData_Rodent.R
+++ b/R/wrangleData_Rodent.R
@@ -99,7 +99,14 @@ wrangleData_Rodent <- function(duplTransects, localities = NULL, areas = NULL, a
     }
   }
  
+  ## Z-standardize covariate values
+  meanCov <- mean(rodentAvg, na.rm = TRUE)
+  sdCov <- sd(rodentAvg, na.rm = TRUE)
+  rodentAvg <- (rodentAvg - meanCov) / sdCov
+  
   ## Return data
-  return(rodentAvg)
+  return(list(rodentAvg = rodentAvg,
+              meanCov = meanCov, 
+              sdCov = sdCov))
   
 }


### PR DESCRIPTION
Mixing of both the intercept (Mu.R) and the rodent covariate effect (betaR.R) seem to be improved (at least for Lierne Vest) when the rodent covariate is z-standardized instead of used untransformed. 